### PR TITLE
Allow CLI + options to start outside quotes

### DIFF
--- a/Sun/sun.cpp
+++ b/Sun/sun.cpp
@@ -744,8 +744,31 @@ int entry(std::vector<std::string>&& args, bool console)
 		&& args[i].c_str()[0] == '+'
 		)
 	{
-		extralines.emplace_back(args[i].substr(1));
-		++i;
+		if (args[i].size() > 1 && args[i][1] == '"')
+		{
+			std::string line = args[i].substr(2);
+			while (true)
+			{
+				if (!line.empty() && line.back() == '"')
+				{
+					line.pop_back();
+					break;
+				}
+				if (args.size() <= ++i)
+				{
+					break;
+				}
+				line.push_back(' ');
+				line.append(args[i]);
+			}
+			extralines.emplace_back(std::move(line));
+			++i;
+		}
+		else
+		{
+			extralines.emplace_back(args[i].substr(1));
+			++i;
+		}
 	}
 
 	SOUP_IF_UNLIKELY (args.size() > i

--- a/docs/Config (.sun file).md
+++ b/docs/Config (.sun file).md
@@ -114,4 +114,4 @@ compiler em++
 
 As you may have noticed, the .sun file is parsed line-by-line. You can add additional lines via the CLI using `+`, for example `sun +32bit` loads the file `.sun` and acts as if a line in that file reads `32bit`.
 
-Note that if the added line contains a space, the argument needs to be quoted like so: `sun "+name myproject"`
+Note that if the added line contains a space, the argument needs to be quoted, either like `sun +"name myproject"` or `sun "+name myproject"`.


### PR DESCRIPTION
## Summary
- handle `+"` arguments by unsplitting and removing quotes
- document that placing `+` before the opening quote is supported

## Testing
- `g++ -std=c++17 -I Sun/vendor/Soup -I Sun/vendor/Soup/soup Sun/sun.cpp Sun/vendor/Soup/soup/*.cpp -o sun_prog`
- `./sun_prog +"name my project"`


------
https://chatgpt.com/codex/tasks/task_e_68b3007a84fc8325a8df60174a58e68e