### PR TITLE
Add macOS 14 ARM64 build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,24 @@ jobs:
           name: "MacOS (X86)"
           path: suncli
 
+  macos-14-arm64:
+    runs-on: macos-14
+    architecture: arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Soup
+        run: php Sun/vendor/Soup/build_lib.php
+
+      - name: Build Sun
+        run: clang -O3 -arch arm64 -o suncli Sun/sun.cpp -ISun/vendor/Soup Sun/vendor/Soup/libsoup.a -std=c++17 -lstdc++
+
+      - name: Upload Sun
+        uses: actions/upload-artifact@v4
+        with:
+          name: "MacOS (ARM64)"
+          path: suncli
+
   windows-latest:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
+---
 name: Build
 
-on: push
+'on':
+  push:
 
 jobs:
   debian-10:
@@ -12,7 +14,10 @@ jobs:
         run: php Sun/vendor/Soup/build_lib.php
 
       - name: Build Sun
-        run: clang -O3 -o suncli Sun/sun.cpp -ISun/vendor/Soup Sun/vendor/Soup/libsoup.a -std=c++17 -fuse-ld=lld -lstdc++ -lstdc++fs -pthreads
+        run: |
+          clang -O3 -o suncli Sun/sun.cpp -ISun/vendor/Soup \
+            Sun/vendor/Soup/libsoup.a -std=c++17 -fuse-ld=lld \
+            -lstdc++ -lstdc++fs -pthreads
 
       - name: Upload Sun
         uses: actions/upload-artifact@v4
@@ -29,7 +34,9 @@ jobs:
         run: php Sun/vendor/Soup/build_lib.php
 
       - name: Build Sun
-        run: clang -O3 -o suncli Sun/sun.cpp -ISun/vendor/Soup Sun/vendor/Soup/libsoup.a -std=c++17 -lstdc++
+        run: |
+          clang -O3 -o suncli Sun/sun.cpp -ISun/vendor/Soup \
+            Sun/vendor/Soup/libsoup.a -std=c++17 -lstdc++
 
       - name: Upload Sun
         uses: actions/upload-artifact@v4
@@ -38,8 +45,9 @@ jobs:
           path: suncli
 
   macos-14-arm64:
-    runs-on: macos-14
-    architecture: arm64
+    runs-on:
+      os: macos-14
+      architecture: arm64
     steps:
       - uses: actions/checkout@v4
 
@@ -47,7 +55,9 @@ jobs:
         run: php Sun/vendor/Soup/build_lib.php
 
       - name: Build Sun
-        run: clang -O3 -arch arm64 -o suncli Sun/sun.cpp -ISun/vendor/Soup Sun/vendor/Soup/libsoup.a -std=c++17 -lstdc++
+        run: |
+          clang -O3 -arch arm64 -o suncli Sun/sun.cpp -ISun/vendor/Soup \
+            Sun/vendor/Soup/libsoup.a -std=c++17 -lstdc++
 
       - name: Upload Sun
         uses: actions/upload-artifact@v4
@@ -64,7 +74,9 @@ jobs:
         run: php Sun/vendor/Soup/build_lib.php
 
       - name: Build Sun
-        run: clang -O3 -o Sun.exe Sun/sun.cpp -ISun/vendor/Soup Sun/vendor/Soup/soup.lib -std=c++17
+        run: |
+          clang -O3 -o Sun.exe Sun/sun.cpp -ISun/vendor/Soup \
+            Sun/vendor/Soup/soup.lib -std=c++17
 
       - name: Upload Sun
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- add macOS 14 arm64 build job

## Testing
- `yamllint .github/workflows/build.yml` *(fails: missing document start, wrong new line character, line length)*

------
https://chatgpt.com/codex/tasks/task_e_68b309ebaddc8325bb5a6a1b3ca53d6c