### PR TITLE
feat: add global compiler arguments

### DIFF
--- a/Sun/sun.cpp
+++ b/Sun/sun.cpp
@@ -54,9 +54,9 @@ struct Project
 	soup::AtomicStack<std::filesystem::path> cpps{};
 	bool opt_static = false;
 	bool opt_dynamic = false;
-	bool opt_32bit = false;
 	bool opt_rtti = false;
 	std::vector<std::string> extra_args{};
+	std::vector<std::string> global_args{};
 	std::vector<std::string> extra_linker_args{};
 
 	Project(std::filesystem::path dir, std::string name = {})
@@ -265,6 +265,12 @@ struct Project
 				continue;
 			}
 
+			if (line.substr(0, 11) == "global_arg ")
+			{
+				global_args.emplace_back(line.substr(11));
+				continue;
+			}
+
 			if (line.substr(0, 11) == "linker_arg ")
 			{
 				extra_linker_args.emplace_back(line.substr(11));
@@ -289,7 +295,7 @@ struct Project
 
 			if (line == "32bit")
 			{
-				opt_32bit = true;
+				global_args.emplace_back("-m32");
 				continue;
 			}
 
@@ -352,9 +358,9 @@ struct Project
 		{
 			hash = soup::joaat::concat(hash, extra_arg);
 		}
-		if (opt_32bit)
+		for (const auto& arg : global_args)
 		{
-			hash = soup::joaat::concat(hash, "-m32");
+			hash = soup::joaat::concat(hash, arg);
 		}
 		return soup::string::hex(hash);
 	}
@@ -416,10 +422,7 @@ struct Project
 		}
 		compiler.rtti = opt_rtti;
 		compiler.extra_args = extra_args;
-		if (opt_32bit)
-		{
-			compiler.extra_args.emplace_back("-m32");
-		}
+		compiler.extra_args.insert(compiler.extra_args.end(), global_args.begin(), global_args.end());
 		compiler.extra_linker_args = extra_linker_args;
 		return compiler;
 	}
@@ -455,7 +458,7 @@ struct Project
 					exit(E_BADDEPEND);
 				}
 
-				dep_proj.opt_32bit = opt_32bit;
+				dep_proj.global_args.insert(dep_proj.global_args.end(), global_args.begin(), global_args.end());
 
 				if (dep_proj.opt_static && opt_static) // Static library depending on a static library?
 				{

--- a/docs/Config (.sun file).md
+++ b/docs/Config (.sun file).md
@@ -78,6 +78,7 @@ cpp 20
 ## Compiler arguments
 
 You can pass arbitrary arguments to the compiler with the `arg` keyword.
+`global_arg` works the same but also applies to all dependencies.
 
 You can define preprocessor macros with the `define` keyword. For example:
 
@@ -96,7 +97,7 @@ By default, Sun adds `-fno-rtti` to the compiler arguments. To have it omitted, 
 
 ## 32-bit targets
 
-You can add a line that reads `32bit` to the .sun file to add `-m32` to the compilation of your project and its dependencies.
+You can add a line that reads `32bit` to the .sun file to add `-m32` to the global compiler arguments of your project and its dependencies (equivalent to `global_arg -m32`).
 
 ## Conditionals
 


### PR DESCRIPTION
## Summary
- allow specifying `global_arg` in project files so flags apply to dependencies
- treat `32bit` directive as shorthand for `global_arg -m32`

## Testing
- `g++ -std=c++20 -I Sun/vendor/Soup -pthread -c Sun/sun.cpp -o /tmp/sun.o && echo 'Compilation succeeded'`


------
https://chatgpt.com/codex/tasks/task_e_68b30aaee004832596df84a13f2de8b7