### PR TITLE
Add macOS 14 build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+
       - name: Build Soup
         run: php Sun/vendor/Soup/build_lib.php
 
@@ -51,7 +56,7 @@ jobs:
       - name: Upload Sun
         uses: actions/upload-artifact@v4
         with:
-          name: "MacOS (ARM)"
+          name: "MacOS (ARM64)"
           path: suncli
 
   windows-latest:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,23 @@ jobs:
           name: "MacOS (X86)"
           path: suncli
 
+  macos-14:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Soup
+        run: php Sun/vendor/Soup/build_lib.php
+
+      - name: Build Sun
+        run: clang -O3 -o suncli Sun/sun.cpp -ISun/vendor/Soup Sun/vendor/Soup/libsoup.a -std=c++17 -lstdc++
+
+      - name: Upload Sun
+        uses: actions/upload-artifact@v4
+        with:
+          name: "MacOS (ARM)"
+          path: suncli
+
   windows-latest:
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
## Summary
- add macOS 14 job to GitHub Actions workflow

## Testing
- `actionlint .github/workflows/build.yml` *(fails: label "debian-10" is unknown)*
- `actionlint -ignore 'label "debian-10" is unknown' -ignore 'label "macos-13" is unknown' .github/workflows/build.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b30c24518c8325bf6d77feb3d40507