### PR TITLE
ci: build examples in debian workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,14 @@ jobs:
       - name: Build Sun
         run: clang -O3 -o suncli Sun/sun.cpp -ISun/vendor/Soup Sun/vendor/Soup/libsoup.a -std=c++17 -fuse-ld=lld -lstdc++ -lstdc++fs -pthreads
 
+      - name: Build examples
+        run: |
+          root=$(pwd)
+          for sunfile in $(find examples -name '.sun'); do
+            dir=$(dirname "$sunfile")
+            (cd "$dir" && "$root/suncli")
+          done
+
       - name: Upload Sun
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- build all example projects during Debian CI job to ensure examples compile

## Testing
- `yamllint .github/workflows/build.yml` *(fails: line too long and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b3cf15a8348325a1fbacb332baa74d